### PR TITLE
fix: add layout_measurement type

### DIFF
--- a/xsdTemplate.xml
+++ b/xsdTemplate.xml
@@ -16,6 +16,14 @@
         </xs:union>
     </xs:simpleType>
 
+    <xs:simpleType name="layout_measurement">
+        <xs:union>
+            <xs:simpleType>
+                <xs:restriction base="xs:integer" />
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+
     <xs:simpleType name="number">
         <xs:union>
             <xs:simpleType>


### PR DESCRIPTION
This resolves 108 errors when generating from 101038 and 101039 documentation.

I believe `xs:integer` is appropriate for layout unless I've overlooked something.